### PR TITLE
remove "g" flag from `passwordRegex`

### DIFF
--- a/server/routes/auth.routes.ts
+++ b/server/routes/auth.routes.ts
@@ -12,7 +12,7 @@ const router = express.Router();
 const saltRounds = 10;
 
 const passwordRegex =
-  /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{12,}$/g;
+  /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{12,}$/;
 
 const passwordRegexNotMatchingError =
   "Your password must have at least 12 characters and contain at least one number, one lowercase, one uppercase and one special character.";


### PR DESCRIPTION
Hi :)

I wanted to use my password "FScjciMk7iKiZ9f!", but received the message from `passwordRegexNotMatchingError`.

It seems that `regex.test(str)` is stateful and somewhat unpredictable when using the g flag. See:
```js
const regex =
  /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{12,}$/g
const pwd = 'FScjciMk7iKiZ9f!'
console.log(regex.test(pwd)) // true
console.log(regex.test(pwd)) // false
console.log(regex.test(pwd)) // true
console.log(regex.test(pwd)) // false
```

I found the same regex without the g flag at https://uibakery.io/regex-library/password

The frontend regexes in usePasswordField.tsx are fine.

TL;DR: Use g when looking for multiple matches within a string, don't use it when validating the string as a whole.
